### PR TITLE
docs: add net/http usage example

### DIFF
--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-thin/go-auth/internal/storage/memory"
+	"github.com/go-thin/go-auth/pkg/auth"
+)
+
+type registerRequest struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func main() {
+	svc, err := auth.New(auth.Config{
+		Storage: memory.NewInMemoryStorage(),
+		JWT: auth.JWTConfig{
+			AccessSecret:    []byte("dev-access-secret-change-me"),
+			RefreshSecret:   []byte("dev-refresh-secret-change-me"),
+			Issuer:          "go-auth-http-example",
+			AccessTokenTTL:  15 * time.Minute,
+			RefreshTokenTTL: 24 * time.Hour,
+			SigningMethod:   auth.HS256,
+		},
+	})
+	if err != nil {
+		log.Fatalf("create auth service: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/register", registerHandler(svc))
+	mux.HandleFunc("/login", loginHandler(svc))
+	mux.HandleFunc("/protected", protectedHandler(svc))
+
+	log.Println("listening on http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+func registerHandler(svc *auth.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "use POST")
+			return
+		}
+
+		var req registerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+
+		user, err := svc.Register(auth.RegisterPayload{
+			Username: req.Username,
+			Email:    req.Email,
+			Password: req.Password,
+		})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, user)
+	}
+}
+
+func loginHandler(svc *auth.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "use POST")
+			return
+		}
+
+		var req loginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+
+		tokens, err := svc.Login(req.Username, req.Password, nil)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, tokens)
+	}
+}
+
+func protectedHandler(svc *auth.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "use GET")
+			return
+		}
+
+		token, ok := bearerToken(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "missing Bearer token")
+			return
+		}
+
+		claims, err := svc.ValidateAccessToken(token)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "invalid token")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"message": "welcome to the protected route",
+			"claims":  claims,
+		})
+	}
+}
+
+func bearerToken(r *http.Request) (string, bool) {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return "", false
+	}
+
+	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+	return token, token != ""
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("write response: %v", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, errorResponse{Error: message})
+}

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/go-thin/go-auth/internal/storage/memory"
@@ -45,7 +44,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/register", registerHandler(svc))
 	mux.HandleFunc("/login", loginHandler(svc))
-	mux.HandleFunc("/protected", protectedHandler(svc))
+	mux.Handle("/protected", auth.Middleware(svc)(protectedHandler()))
 
 	log.Println("listening on http://localhost:8080")
 	log.Fatal(http.ListenAndServe(":8080", mux))
@@ -101,40 +100,20 @@ func loginHandler(svc *auth.Service) http.HandlerFunc {
 	}
 }
 
-func protectedHandler(svc *auth.Service) http.HandlerFunc {
+func protectedHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			writeError(w, http.StatusMethodNotAllowed, "use GET")
 			return
 		}
 
-		token, ok := bearerToken(r)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "missing Bearer token")
-			return
-		}
-
-		claims, err := svc.ValidateAccessToken(token)
-		if err != nil {
-			writeError(w, http.StatusUnauthorized, "invalid token")
-			return
-		}
+		claims, _ := auth.ClaimsFromContext(r.Context())
 
 		writeJSON(w, http.StatusOK, map[string]any{
 			"message": "welcome to the protected route",
 			"claims":  claims,
 		})
 	}
-}
-
-func bearerToken(r *http.Request) (string, bool) {
-	authHeader := r.Header.Get("Authorization")
-	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return "", false
-	}
-
-	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
-	return token, token != ""
 }
 
 func writeJSON(w http.ResponseWriter, status int, value any) {


### PR DESCRIPTION
## Summary
- add `examples/http/main.go` with a small `net/http` server using the in-memory storage backend
- wire `POST /register` to `svc.Register`
- wire `POST /login` to `svc.Login` and return access/refresh tokens
- wire `GET /protected` to validate `Authorization: Bearer <token>` before serving the route

Fixes #11

## Validation
- Checked the example against the current `auth.New`, `Register`, `Login`, `ValidateAccessToken`, and `memory.NewInMemoryStorage` APIs
- `git diff --cached --check`

Note: this Windows Codex shell does not have `go`, `gofmt`, or Docker installed on PATH, so I could not run `gofmt` or `go test ./...` locally. The file is formatted in standard gofmt style by inspection.