### PR TITLE
feat: add bearer token middleware

### DIFF
--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type claimsContextKey struct{}
+
+// ClaimsFromContext returns JWT claims stored by Middleware.
+func ClaimsFromContext(ctx context.Context) (jwt.MapClaims, bool) {
+	claims, ok := ctx.Value(claimsContextKey{}).(jwt.MapClaims)
+	return claims, ok
+}
+
+// Middleware validates Bearer access tokens and stores their claims in the request context.
+func Middleware(svc *Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, ok := bearerToken(r.Header.Get("Authorization"))
+			if !ok {
+				unauthorized(w)
+				return
+			}
+
+			claims, err := svc.ValidateAccessToken(token)
+			if err != nil {
+				unauthorized(w)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), claimsContextKey{}, claims)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func bearerToken(header string) (string, bool) {
+	scheme, token, ok := strings.Cut(header, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") {
+		return "", false
+	}
+
+	token = strings.TrimSpace(token)
+	return token, token != ""
+}
+
+func unauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", "Bearer")
+	http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+}

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newMiddlewareTestService(t *testing.T) *Service {
+	t.Helper()
+
+	svc, err := New(Config{
+		Storage: newSimpleStorage(),
+		JWT: JWTConfig{
+			AccessSecret:    []byte("access-secret"),
+			RefreshSecret:   []byte("refresh-secret"),
+			AccessTokenTTL:  time.Minute,
+			RefreshTokenTTL: time.Hour,
+			SigningMethod:   HS256,
+		},
+	})
+	if err != nil {
+		t.Fatalf("auth.New: %v", err)
+	}
+
+	return svc
+}
+
+func newMiddlewareTestToken(t *testing.T, svc *Service) string {
+	t.Helper()
+
+	if _, err := svc.Register(RegisterPayload{
+		Username: "alice",
+		Email:    "alice@example.com",
+		Password: "password123",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	tokens, err := svc.Login("alice", "password123", map[string]interface{}{
+		"role": "admin",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	return tokens.AccessToken
+}
+
+func TestMiddleware_StoresClaimsInRequestContext(t *testing.T) {
+	svc := newMiddlewareTestService(t)
+	token := newMiddlewareTestToken(t, svc)
+
+	handler := Middleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := ClaimsFromContext(r.Context())
+		if !ok {
+			t.Fatal("claims missing from request context")
+		}
+		if claims["username"] != "alice" {
+			t.Errorf("username claim = %v, want %q", claims["username"], "alice")
+		}
+		if claims["role"] != "admin" {
+			t.Errorf("role claim = %v, want %q", claims["role"], "admin")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
+func TestMiddleware_RejectsMissingAuthorizationHeader(t *testing.T) {
+	svc := newMiddlewareTestService(t)
+	called := false
+	handler := Middleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Fatal("next handler was called")
+	}
+}
+
+func TestMiddleware_RejectsInvalidAuthorizationHeader(t *testing.T) {
+	svc := newMiddlewareTestService(t)
+	called := false
+	handler := Middleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Token not-a-bearer-token")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Fatal("next handler was called")
+	}
+}
+
+func TestMiddleware_RejectsInvalidBearerToken(t *testing.T) {
+	svc := newMiddlewareTestService(t)
+	called := false
+	handler := Middleware(svc)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Fatal("next handler was called")
+	}
+}


### PR DESCRIPTION
## Summary

- add a `pkg/auth` HTTP middleware for `Authorization: Bearer <token>` access tokens
- store validated JWT claims on the request context
- add `ClaimsFromContext` for handlers to read middleware-injected claims
- reject missing, malformed, and invalid tokens with `401 Unauthorized`

Closes #13

## Tests

- `go test ./pkg/auth`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
