### PR TITLE
feat: configure argon2 params

### DIFF
--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -3,8 +3,8 @@ package auth
 import (
 	"time"
 
-	goevents "github.com/go-thin/go-events"
 	"github.com/go-thin/go-auth/pkg/storage"
+	goevents "github.com/go-thin/go-events"
 )
 
 // SigningMethod defines the type for JWT signing methods.
@@ -29,7 +29,8 @@ type JWTConfig struct {
 // Config is the main configuration struct for the AuthService.
 // It holds all the necessary components and settings.
 type Config struct {
-	Storage  storage.Storage
-	JWT      JWTConfig
-	EventBus goevents.Bus // optional; nil disables event publishing
+	Storage      storage.Storage
+	JWT          JWTConfig
+	Argon2Params *Argon2Params // optional; nil uses DefaultParams
+	EventBus     goevents.Bus  // optional; nil disables event publishing
 }

--- a/pkg/auth/hashing.go
+++ b/pkg/auth/hashing.go
@@ -32,7 +32,14 @@ var DefaultParams = &Argon2Params{
 // HashPassword generates a secure Argon2id hash of a password.
 // The output format is a modular crypt format string containing all parameters.
 func HashPassword(password string) (string, error) {
-	p := DefaultParams
+	return hashPasswordWithParams(password, nil)
+}
+
+func hashPasswordWithParams(password string, params *Argon2Params) (string, error) {
+	p := params
+	if p == nil {
+		p = DefaultParams
+	}
 
 	// 1. Generate a cryptographically secure random salt.
 	salt := make([]byte, p.SaltLength)

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/golang-jwt/jwt/v5"
-	goevents "github.com/go-thin/go-events"
 	"github.com/go-thin/go-auth/internal/jwtutils"
 	"github.com/go-thin/go-auth/pkg/models"
 	"github.com/go-thin/go-auth/pkg/storage"
+	goevents "github.com/go-thin/go-events"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/google/uuid"
 )
@@ -17,9 +17,10 @@ import (
 // Service provides high-level authentication operations.
 // It orchestrates user storage, password hashing, and token generation.
 type Service struct {
-	storage    storage.Storage
-	jwtManager jwtutils.TokenManager
-	eventBus   goevents.Bus
+	storage      storage.Storage
+	jwtManager   jwtutils.TokenManager
+	argon2Params *Argon2Params
+	eventBus     goevents.Bus
 }
 
 // New creates a new Service from a configuration.
@@ -44,9 +45,10 @@ func New(cfg Config) (*Service, error) {
 	})
 
 	return &Service{
-		storage:    cfg.Storage,
-		jwtManager: jwtManager,
-		eventBus:   cfg.EventBus,
+		storage:      cfg.Storage,
+		jwtManager:   jwtManager,
+		argon2Params: cfg.Argon2Params,
+		eventBus:     cfg.EventBus,
 	}, nil
 }
 
@@ -71,7 +73,7 @@ func (s *Service) Register(payload RegisterPayload) (*models.User, error) {
 		return nil, fmt.Errorf("user with username '%s' already exists", payload.Username)
 	}
 
-	passwordHash, err := HashPassword(payload.Password)
+	passwordHash, err := hashPasswordWithParams(payload.Password, s.argon2Params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
 	}

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	goevents "github.com/go-thin/go-events"
 	"github.com/go-thin/go-auth/pkg/models"
+	goevents "github.com/go-thin/go-events"
 )
 
 // recordingBus captures every event passed to Publish.
@@ -59,7 +59,7 @@ func newTestService(t *testing.T, bus goevents.Bus) *Service {
 		JWT: JWTConfig{
 			AccessSecret:  []byte("access-secret"),
 			RefreshSecret: []byte("refresh-secret"),
-			SigningMethod:  HS256,
+			SigningMethod: HS256,
 		},
 		EventBus: bus,
 	})
@@ -112,6 +112,96 @@ func TestRegister_PublishesUserRegisteredEvent(t *testing.T) {
 	}
 	if e.UserID == "" {
 		t.Error("UserID is empty")
+	}
+}
+
+func TestRegister_UsesConfiguredArgon2Params(t *testing.T) {
+	store := newSimpleStorage()
+	params := &Argon2Params{
+		Memory:      32,
+		Iterations:  2,
+		Parallelism: 1,
+		SaltLength:  8,
+		KeyLength:   16,
+	}
+	svc, err := New(Config{
+		Storage: store,
+		JWT: JWTConfig{
+			AccessSecret:  []byte("access-secret"),
+			RefreshSecret: []byte("refresh-secret"),
+			SigningMethod: HS256,
+		},
+		Argon2Params: params,
+	})
+	if err != nil {
+		t.Fatalf("auth.New: %v", err)
+	}
+
+	if _, err := svc.Register(RegisterPayload{
+		Username: "custom",
+		Email:    "custom@example.com",
+		Password: "password123",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	user, err := store.GetUserByUsername("custom")
+	if err != nil {
+		t.Fatalf("GetUserByUsername: %v", err)
+	}
+
+	gotParams, _, _, err := decodeHash(user.PasswordHash)
+	if err != nil {
+		t.Fatalf("decodeHash: %v", err)
+	}
+
+	if *gotParams != *params {
+		t.Fatalf("argon2 params = %+v, want %+v", gotParams, params)
+	}
+
+	valid, err := VerifyPassword("password123", user.PasswordHash)
+	if err != nil {
+		t.Fatalf("VerifyPassword: %v", err)
+	}
+	if !valid {
+		t.Fatal("registered password should verify")
+	}
+}
+
+func TestRegister_UsesDefaultArgon2ParamsWhenConfigNil(t *testing.T) {
+	store := newSimpleStorage()
+	svc, err := New(Config{
+		Storage: store,
+		JWT: JWTConfig{
+			AccessSecret:  []byte("access-secret"),
+			RefreshSecret: []byte("refresh-secret"),
+			SigningMethod: HS256,
+		},
+	})
+	if err != nil {
+		t.Fatalf("auth.New: %v", err)
+	}
+
+	if _, err := svc.Register(RegisterPayload{
+		Username: "default",
+		Email:    "default@example.com",
+		Password: "password123",
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	user, err := store.GetUserByUsername("default")
+	if err != nil {
+		t.Fatalf("GetUserByUsername: %v", err)
+	}
+
+	gotParams, _, _, err := decodeHash(user.PasswordHash)
+	if err != nil {
+		t.Fatalf("decodeHash: %v", err)
+	}
+
+	if *gotParams != *DefaultParams {
+		t.Fatalf("argon2 params = %+v, want %+v", gotParams, DefaultParams)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add optional `Argon2Params *Argon2Params` to `auth.Config`
- use configured Argon2id parameters when `Service.Register` hashes new passwords
- keep `HashPassword` default behavior unchanged when no params are configured
- cover custom and default service registration paths with tests

Closes #9

## Tests

- `go test ./pkg/auth`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
