### PR TITLE
feat: add DeleteUser to storage interface and backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Both backends auto-create the `users` table on first open. `store.DB()` exposes 
 
 ## Implementing a custom storage backend
 
-Implement the two-method `storage.Storage` interface to plug in any other backend:
+Implement the three-method `storage.Storage` interface to plug in any other backend:
 
 ```go
 import (
@@ -143,6 +143,7 @@ type MyDB struct{}
 
 func (db *MyDB) CreateUser(user models.User) error                        { /* insert */ return nil }
 func (db *MyDB) GetUserByUsername(username string) (*models.User, error)  { /* select */ return nil, nil }
+func (db *MyDB) DeleteUser(id string) error                               { /* delete */ return nil }
 // Return storage.ErrUserNotFound when the user does not exist.
 ```
 

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -37,3 +37,15 @@ func (s *InMemoryStorage) GetUserByUsername(username string) (*models.User, erro
 	}
 	return &u, nil
 }
+
+func (s *InMemoryStorage) DeleteUser(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for username, user := range s.users {
+		if user.ID == id {
+			delete(s.users, username)
+			return nil
+		}
+	}
+	return nil
+}

--- a/internal/storage/memory/memory_test.go
+++ b/internal/storage/memory/memory_test.go
@@ -1,0 +1,36 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/go-thin/go-auth/pkg/models"
+	"github.com/go-thin/go-auth/pkg/storage"
+)
+
+var _ storage.Storage = (*InMemoryStorage)(nil)
+
+func TestDeleteUser_RemovesUser(t *testing.T) {
+	store := NewInMemoryStorage()
+
+	user := models.User{
+		ID:           "u-delete",
+		Username:     "delete-me",
+		Email:        "delete-me@example.com",
+		PasswordHash: "h",
+	}
+	if err := store.CreateUser(user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := store.DeleteUser("u-delete"); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	_, err := store.GetUserByUsername("delete-me")
+	if err == nil {
+		t.Fatal("expected user to be deleted")
+	}
+	if err != storage.ErrUserNotFound {
+		t.Errorf("error = %v, want storage.ErrUserNotFound", err)
+	}
+}

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -52,6 +52,16 @@ func (s *simpleStorage) GetUserByUsername(username string) (*models.User, error)
 	return u, nil
 }
 
+func (s *simpleStorage) DeleteUser(id string) error {
+	for username, user := range s.users {
+		if user.ID == id {
+			delete(s.users, username)
+			return nil
+		}
+	}
+	return nil
+}
+
 func newTestService(t *testing.T, bus goevents.Bus) *Service {
 	t.Helper()
 	svc, err := New(Config{

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -13,4 +13,5 @@ var ErrUserNotFound = errors.New("user not found")
 type Storage interface {
 	CreateUser(user models.User) error
 	GetUserByUsername(username string) (*models.User, error)
+	DeleteUser(id string) error
 }

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -76,3 +76,11 @@ func (s *Store) GetUserByUsername(username string) (*models.User, error) {
 	}
 	return &u, nil
 }
+
+func (s *Store) DeleteUser(id string) error {
+	_, err := s.db.Exec(`DELETE FROM users WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("postgres: delete user: %w", err)
+	}
+	return nil
+}

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -79,3 +79,24 @@ func TestGetUserByUsername_NotFound(t *testing.T) {
 		t.Errorf("error = %v, want storage.ErrUserNotFound", err)
 	}
 }
+
+func TestDeleteUser_RemovesUser(t *testing.T) {
+	store := newTestStore(t)
+
+	user := models.User{ID: "u-delete", Username: "delete-me", Email: "delete-me@example.com", PasswordHash: "h"}
+	if err := store.CreateUser(user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := store.DeleteUser("u-delete"); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	_, err := store.GetUserByUsername("delete-me")
+	if err == nil {
+		t.Fatal("expected user to be deleted")
+	}
+	if err != storage.ErrUserNotFound {
+		t.Errorf("error = %v, want storage.ErrUserNotFound", err)
+	}
+}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -76,3 +76,11 @@ func (s *Store) GetUserByUsername(username string) (*models.User, error) {
 	}
 	return &u, nil
 }
+
+func (s *Store) DeleteUser(id string) error {
+	_, err := s.db.Exec(`DELETE FROM users WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("sqlite: delete user: %w", err)
+	}
+	return nil
+}

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -71,3 +71,24 @@ func TestGetUserByUsername_NotFound(t *testing.T) {
 		t.Errorf("error = %v, want storage.ErrUserNotFound", err)
 	}
 }
+
+func TestDeleteUser_RemovesUser(t *testing.T) {
+	store := newTestStore(t)
+
+	user := models.User{ID: "u-delete", Username: "delete-me", Email: "delete-me@example.com", PasswordHash: "h"}
+	if err := store.CreateUser(user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := store.DeleteUser("u-delete"); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	_, err := store.GetUserByUsername("delete-me")
+	if err == nil {
+		t.Fatal("expected user to be deleted")
+	}
+	if err != storage.ErrUserNotFound {
+		t.Errorf("error = %v, want storage.ErrUserNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Extend storage.Storage with DeleteUser(id string) error.
- Implement DeleteUser in both built-in backends (sqlite + postgres).
- Add storage tests for successful user deletion.
- Keep the simple in-memory service test storage implementation compliant with the expanded interface.
- Update README example of custom backend contract.

Closes #12